### PR TITLE
[OSDEV-1785] Pinned kafka-python dependency to version 2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode
+
 ># Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes:
 * Fix `KeyError` on solitary abort marker (issue #781, pr #782 by @pikulmar)
 * Fix handling unsupported compression codec (issue #795)
 * Handled other SASL mechanism in logging (issue #852, pr #861 by @mangin)
+* Pinned kafka-python dependency to version 2.0.3 to ensure compatibility and stability with aiokafka v0.8.0 (issue https://github.com/aio-libs/aiokafka/issues/1093)
 
 
 Improved Documentation:

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ class ve_build_ext(build_ext):
 
 install_requires = [
     "async-timeout",
-    "kafka-python>=2.0.2",
+    "kafka-python==2.0.3",
     "packaging",
 ]
 


### PR DESCRIPTION
### Changes

**Workaround**: Pinned kafka-python dependency to version 2.0.3 to ensure compatibility and stability with aiokafka v0.8.0 (issue https://github.com/aio-libs/aiokafka/issues/1093)

